### PR TITLE
Make proxy compatible with current vault storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ See https://github.com/hashicorp/vault/blob/main/api/client.go for the available
 In addition, the following environment variables can be set:
 
 - `VAULT_PATHPREFIX`: the path prefix to use for the Vault keys, which generally matches the secret store name (defaults to `kv`).
+- `VAULT_PATHNAME`: the path name to use for the Vault keys, which generally matches the secret store name (defaults to `nuts-private-keys`).
+
+## Backwards compatibility
+
+The Vault proxy can be used as a drop-in replacement for the embedded Nuts node Vault secret storage engine. If you already have your keys in Hashicorp Vault and want to use the proxy, make sure to set the `VAULT_PATHPREFIX` to your nodes `crypto.vault.pathprefix` value of leave it empty for default and leave `VAULT_PATHNAME` empty.
 
 ## Test suite
 

--- a/api/v1/generated.go
+++ b/api/v1/generated.go
@@ -46,11 +46,11 @@ type ErrorResponse struct {
 // Key The key under which secrets can be stored or retrieved.
 //
 // The key should be considered opaque and no assumptions should be made about its value or format.
-// Since the key is the last part of the URL path, slashes and hash symbols must be escaped.
+// Note: When the key is used in the URL path, symbols such as slashes and hash symbols must be escaped.
 type Key = string
 
 // KeyList List of keys currently stored in the store.
-// Note: If the client escaped these keys, they should be unescaped before using them.
+// Note: Keys will be in unescaped form. No assumptions should be made about the order of the keys.
 type KeyList = []Key
 
 // Secret The secret value stored under the provided key.

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ package main
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 
 	"github.com/labstack/echo/v4"
@@ -33,12 +34,23 @@ const listenAddress = ":8210"
 
 func main() {
 	logrus.Info("Starting the Hashicorp Vault Proxy...")
+
 	pathPrefix := os.Getenv("VAULT_PATHPREFIX")
 	if pathPrefix == "" {
 		pathPrefix = "kv"
 	}
 
-	kv, err := vault.NewKVStore(pathPrefix)
+	pathName := os.Getenv("VAULT_PATHNAME")
+	if pathName == "" {
+		pathName = "nuts-private-keys"
+	}
+
+	path, err := url.JoinPath(pathPrefix, pathName)
+	if err != nil {
+		panic(fmt.Errorf("unable to assemble vault secret path: %w", err))
+	}
+
+	kv, err := vault.NewKVStore(path)
 	if err != nil {
 		panic(fmt.Errorf("unable to create Vault KVStore: %w", err))
 	}

--- a/main.go
+++ b/main.go
@@ -35,16 +35,19 @@ const listenAddress = ":8210"
 func main() {
 	logrus.Info("Starting the Hashicorp Vault Proxy...")
 
+	// pathPrefix should always be set
 	pathPrefix := os.Getenv("VAULT_PATHPREFIX")
 	if pathPrefix == "" {
 		pathPrefix = "kv"
 	}
 
-	pathName := os.Getenv("VAULT_PATHNAME")
-	if pathName == "" {
+	// pathName is optional
+	pathName, isSet := os.LookupEnv("VAULT_PATHNAME")
+	if !isSet {
 		pathName = "nuts-private-keys"
 	}
 
+	// JoinPath will only add a slash if pathName is set
 	path, err := url.JoinPath(pathPrefix, pathName)
 	if err != nil {
 		panic(fmt.Errorf("unable to assemble vault secret path: %w", err))

--- a/vault/kv_test.go
+++ b/vault/kv_test.go
@@ -20,7 +20,6 @@ package vault
 import (
 	"encoding/base64"
 	"errors"
-	"net/url"
 	"strings"
 	"testing"
 
@@ -96,7 +95,6 @@ var encodedSecret = []byte(base64.StdEncoding.EncodeToString(secret))
 const prefix = "kv"
 const kid = "did:nuts:123#abc"
 
-var encodedKid = url.PathEscape(kid)
 var vaultError = errors.New("vault error")
 
 func TestVaultKVStorage(t *testing.T) {
@@ -170,7 +168,7 @@ func TestVaultKVStorage_ListKeys(t *testing.T) {
 		v := KVStorage{pathPrefix: prefix, client: mockVaultClient{store: map[string]map[string]interface{}{storagePath(prefix, kid): {"key": string(encodedSecret)}}}}
 		result, err := v.ListKeys()
 		assert.NoError(t, err)
-		assert.Equal(t, []string{encodedKid}, result)
+		assert.Equal(t, []string{kid}, result)
 	})
 
 	t.Run("error - while listing", func(t *testing.T) {


### PR DESCRIPTION
The Nuts node currently has an embedded `vaultkv` store.
This PR fixes several things to make sure the proxy can be used as a drop in replacement:
* Do not store the keys in encoded form
* Add the `nuts-private-keys` string to the vault secret path
* Consider the secret a string so it wont be base64 encoded