### PR TITLE
set go version to latest in codeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,6 +40,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Use latest Go version
+      uses: actions/setup-go@v4
+      with:
+        go-version: 'stable'
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2


### PR DESCRIPTION
Should fix Security tab's complaints about the go version in the CodeQL action
> Newer Go version needed
> The detected version of Go is lower than the version specified in go.mod.