### PR TITLE
Group dependabot updates into weekly PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,18 +9,39 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
-      
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
   # Go
   - package-ecosystem: "gomod"
     # checks /go.mod
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      go-modules:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # Docker
   - package-ecosystem: "docker"
     # checks /Dockerfile
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      docker:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Switch dependabot from daily, ungrouped updates to **weekly grouped** PRs.

- `github-actions`, `gomod`, and `docker`: weekly, grouped (minor+patch).
- **Major** bumps stay outside the groups as individual PRs, so cross-breaking-change updates that need judgment remain individually reviewable.
- Preserves soak time and anti-drift currency.

Assisted by AI